### PR TITLE
Add missing jq package to voltlet

### DIFF
--- a/voltlet/Dockerfile
+++ b/voltlet/Dockerfile
@@ -23,7 +23,7 @@ ENV GOPATH="/go"
 RUN apk add --no-cache --virtual build-dependencies go wget git musl-dev && \
   wget -O /voltlet.tar.gz https://github.com/mcolyer/voltlet/archive/v1.0.0.tar.gz && \
   tar xf /voltlet.tar.gz && \
-  echo $GOPATH && mkdir -p $GOPATH && mkdir -p $GOPATH/src/matt.colyer.name/ && \
+  mkdir -p $GOPATH && mkdir -p $GOPATH/src/matt.colyer.name/ && \
   mv /voltlet-1.0.0 $GOPATH/src/matt.colyer.name/voltlet && \
   cd $GOPATH/src/matt.colyer.name/voltlet && \
   go get && go build -o /voltlet main.go && \

--- a/voltlet/Dockerfile
+++ b/voltlet/Dockerfile
@@ -28,7 +28,8 @@ RUN apk add --no-cache --virtual build-dependencies go wget git musl-dev && \
   cd $GOPATH/src/matt.colyer.name/voltlet && \
   go get && go build -o /voltlet main.go && \
   rm -fr /voltlet.tar.gz /go && \
-  apk del build-dependencies
+  apk del build-dependencies && \
+  apk add --no-cache jq
 
 #
 # Define an environment variable

--- a/voltlet/build.json
+++ b/voltlet/build.json
@@ -1,0 +1,5 @@
+{
+  "build_from": {
+    "armhf": "alpine:3.7"
+  }
+}

--- a/voltlet/config.json
+++ b/voltlet/config.json
@@ -17,6 +17,5 @@
     "mqtt_broker": "str",
     "mqtt_user": "str",
     "mqtt_password": "str"
-  },
-  "image": "mcolyer/hassio-{arch}-voltlet"
+  }
 }

--- a/voltlet/config.json
+++ b/voltlet/config.json
@@ -3,7 +3,6 @@
   "version": "4",
   "slug": "voltlet",
   "description": "Control etekcity voltson outlets with home assistant",
-  "image": "mcolyer/hassio-{arch}-voltlet",
   "startup": "before",
   "boot": "auto",
   "ports": {

--- a/voltlet/config.json
+++ b/voltlet/config.json
@@ -17,5 +17,6 @@
     "mqtt_broker": "str",
     "mqtt_user": "str",
     "mqtt_password": "str"
-  }
+  },
+  "image": "mcolyer/hassio-{arch}-voltlet"
 }

--- a/voltlet/config.json
+++ b/voltlet/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Voltlet",
-  "version": "4",
+  "version": "5",
   "slug": "voltlet",
   "description": "Control etekcity voltson outlets with home assistant",
   "startup": "before",


### PR DESCRIPTION
As reported in #2, voltlet was missing the jq package. I was for some reason unable to reproduce this until switching my install of hassio to the new base image based on buildroot, 🤔.

Fixes #2.